### PR TITLE
Verify default values for boolean fields case sensitively to prevent invalid JSON being generated through using upperchase characters

### DIFF
--- a/Managed Prefs Builder/KeysVC.swift
+++ b/Managed Prefs Builder/KeysVC.swift
@@ -253,8 +253,8 @@ struct KeysView: View {
                 return showError("Default value must be a valid integer.")
             }
         case .boolean:
-            if !defaultValue.isEmpty, !["true", "false"].contains(defaultValue.lowercased()) {
-                return showError("Default value must be either true, false, or blank.")
+            if !defaultValue.isEmpty, !["true", "false"].contains(defaultValue) {
+                return showError("Default value must be either (lowercase) true, false, or blank.")
             }
         case .string:
             break


### PR DESCRIPTION
Hello, 

thanks for creating this tool ! I noticed that it can generate invalid JSON in case you enter TRUE,True,or similar in the default value entry for a boolean key.
I propose removing the lowercasing of the user entered value before comparing to the list of allowed values to prevent this at the earliest possible time, and to slightly change the error message to tell the user to use lower case in case they don't. 